### PR TITLE
Updated .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,8 @@
             "prefix": "app",
             "style": "kebab-case"
           }
-        ]
+        ],
+         "indent": ["error", 2] // custom rule for enforcing 2-space indentation
       }
     },
     {


### PR DESCRIPTION
This adds a new rule for the indent property under the rules section of the TypeScript override. The rule enforces 2-space indentation for TypeScript files. We can adjust the number of spaces to match your preferred indentation style.